### PR TITLE
Fix issue when receiving an empty body on titanium platform

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -333,7 +333,7 @@ function Response(req, options) {
   this.header['content-type'] = this.xhr.getResponseHeader('content-type');
   this._setHeaderProperties(this.header);
   this.body = this.req.method != 'HEAD'
-    ? this._parseBody(this.text ? this.text : this.xhr.response)
+    ? this._parseBody(this.text ? this.text : ((typeof Titanium !== 'undefined') ? '' : this.xhr.response))
     : null;
 }
 


### PR DESCRIPTION
Accessing this.xhr.response causes the ios simulator platform to crash
I didn’t test on device.

However, looking at context of this function it’s safe to say that if 
this.text is not set, there is no body to parse so setting to empty
string is fine.