### PR TITLE
Satisfy titanium deprecated-method-noise in mobile app run-time logs …

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -7,6 +7,12 @@ var reduce = require('reduce');
 var requestBase = require('./request-base');
 var isObject = require('./is-object');
 
+
+/**
+ * Flags
+ */
+var IS_TITANIUM = (typeof Titanium !== 'undefined');
+
 /**
  * Root reference for iframes.
  */
@@ -326,14 +332,14 @@ function Response(req, options) {
      : null;
   this.statusText = this.req.xhr.statusText;
   this._setStatusProperties(this.xhr.status);
-  this.header = this.headers = parseHeader(this.xhr.getAllResponseHeaders()||xhr.responseHeaders||'');
+  this.header = this.headers = parseHeader((IS_TITANIUM ? this.xhr.allResponseHeaders : this.xhr.getAllResponseHeaders())||this.xhr.responseHeaders||'');
   // getAllResponseHeaders sometimes falsely returns "" for CORS requests, but
   // getResponseHeader still works. so we get content-type even if getting
   // other headers fails.
   this.header['content-type'] = this.xhr.getResponseHeader('content-type');
   this._setHeaderProperties(this.header);
   this.body = this.req.method != 'HEAD'
-    ? this._parseBody(this.text ? this.text : ((typeof Titanium !== 'undefined') ? '' : this.xhr.response))
+    ? this._parseBody(this.text ? this.text : (IS_TITANIUM ? '' : this.xhr.response))
     : null;
 }
 
@@ -766,7 +772,7 @@ Request.prototype.end = function(fn){
     }
   };
 
-  if (typeof Titanium !== 'undefined') {
+  if (IS_TITANIUM) {
     xhr.onerror = function() {
       if (!hasAlreadyEnded) {
         hasAlreadyEnded = true;
@@ -775,7 +781,12 @@ Request.prototype.end = function(fn){
     };
 
     if (timeout != null) {
-      xhr.setTimeout(timeout);
+      if (IS_TITANIUM) {
+        xhr.timeout = timeout;
+      }
+      else {
+        xhr.setTimeout(timeout);
+      }
     }
   }
 


### PR DESCRIPTION
…by directly using attributes instead

* timeout
* allResponseHeaders